### PR TITLE
게시글 상세화면 중접 라우팅 설정

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -17,8 +17,9 @@ const App = () => {
     <Routes>
       <Route element={<Layout />}>
         <Route index element={<Main />} />
-        <Route path='/community-list' element={<CommunityList />} />
-        <Route path='/community-list/:id' element={<CommunityContent />} />
+        <Route path='/community-list' element={<CommunityList />}>
+        <Route path=':id' element={<CommunityContent />} />
+        </Route>
         <Route path='/write' element={<Write />} />
         <Route path='/search' element={<Search />} />
         <Route path='/mypage' element={<MyPage />} />

--- a/src/pages/community/CommunityList.js
+++ b/src/pages/community/CommunityList.js
@@ -1,8 +1,10 @@
 import BoardCard from "../../components/common/BoardCard.js";
+import {Outlet} from "react-router-dom";
 
 export default function CommunityList(){
     return (
         <div>
+            <Outlet/>
             커뮤니티 리스트
             <BoardCard/>
         </div>


### PR DESCRIPTION
**작업 내용**

- 게시글 클릭시 중첩 라우팅을 사용하여 목록 위쪽에 게시글이 보이도록 했어요

**해결 방법**

- 중첩 라우팅을 사용할 경우 부모의 라우트 컴포넌트 내에 자식 컴포넌트의 위치를 설정해 줘야하는데 설정해주지 않아서 변화가 없었던것 이였어요
- 부모의 라우트 컴포넌트 내에 `<Outlet/>`으로 자식의 컴포넌트의 위치를 설정해주어 해결했어요.

**추후 작업 내용**
CSS 작업

<div>
<img width="350" alt="스크린샷 2022-10-27 오후 12 21 28" src="https://user-images.githubusercontent.com/82946898/198183813-6ece2c12-d0e0-4e71-a8e8-8c723abd22d7.png" title="해결전" alt="해결전">
<img width="350" height="350" alt="스크린샷 2022-10-27 오후 12 19 52" src="https://user-images.githubusercontent.com/82946898/198183967-79725028-d09f-4494-aa27-a704401020a6.png" title="해결후" alt="해결후">
</div>
<div>해결전 / 해결후</div>

