### PR TITLE
Community List에 dummy,BoardCardContent 추가

### DIFF
--- a/src/pages/community/CommunityList.js
+++ b/src/pages/community/CommunityList.js
@@ -1,6 +1,8 @@
 
 import BoardCard from "../../components/common/BoardCard.js";
 import {Outlet} from "react-router-dom";
+import dummy from "../../db/CommunityList.json"
+import BoardCardContent from "../../components/common/BoardCardContent.js";
 
 export default function CommunityList(){
     return (


### PR DESCRIPTION
**작업 내용**

- Community List 내에 dummy, BoardCardContent 가 사용되었지만 누락되어 import 해주었습니다.

main 브랜치에서 받아왔음에도 불구하고, 실행이 되지않아 바로 머지 하겠습니다.